### PR TITLE
Add Octave support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "external_libs/matconvnet"]
 	path = external_libs/matconvnet
-	url = git@github.com:vlfeat/matconvnet.git
+	url = https://github.com/vlfeat/matconvnet.git
 	ignore = dirty
 [submodule "external_libs/pdollar_toolbox"]
 	path = external_libs/pdollar_toolbox
-	url = git@github.com:pdollar/toolbox.git
+	url = https://github.com/pdollar/toolbox.git
 	ignore = dirty

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Webpage: http://users.isy.liu.se/cvl/marda26/
 
    $ git clone --recurse-submodules https://github.com/martin-danelljan/ECO.git
 
-1. Start Matlab/Octave and navigate to the repository path, run the install script:
+2. Start Matlab/Octave and navigate to the repository path, run the install script:
 
    |>> install
 
-1. Run the demo script to test the tracker:
+3. Run the demo script to test the tracker:
 
    |>> demo_ECO
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ECO
 
-Matlab implementation of the Efficient Convolution Operator (ECO) tracker.
+Matlab/Octave implementation of the Efficient Convolution Operator (ECO) tracker.
 
 <b>News: Version 2.0 is here!</b> 
 * Full GPU support
@@ -42,27 +42,21 @@ Webpage: http://users.isy.liu.se/cvl/marda26/
 
 ### Using git clone
 
-1. Clone the GIT repository:
+1. Clone the GIT repository and submodules:
 
-   $ git clone https://github.com/martin-danelljan/ECO.git
+   $ git clone --recurse-submodules https://github.com/martin-danelljan/ECO.git
 
-2. Clone the submodules.  
-   In the repository directory, run the commands:
-
-   $ git submodule init  
-   $ git submodule update
-
-3. Start Matlab and navigate to the repository.  
-   Run the install script:
+1. Start Matlab/Octave and navigate to the repository path, run the install script:
 
    |>> install
 
-4. Run the demo script to test the tracker:
+1. Run the demo script to test the tracker:
 
    |>> demo_ECO
 
 
-Note:  
+#### Note:
+
 This package requires matconvnet [1], if you want to use deep CNN features, and PDollar Toolbox [2], if you want to use HOG features. Both these externals are included as git submodules and should be installed by following step 2. above.
 
 

--- a/VOT_integration/benchmark_wrapper/benchmark_tracker_wrapper.m
+++ b/VOT_integration/benchmark_wrapper/benchmark_tracker_wrapper.m
@@ -1,7 +1,8 @@
-function benchmark_tracker_wrapper(tracker_name, runfile_name, do_cleanup)
+function benchmark_tracker_wrapper(tracker_name, runfile_name, do_cleanup, is_octave)
 
 if nargin < 3
     do_cleanup = true;
+    is_octave = false;
 end
 
 % *************************************************************
@@ -21,7 +22,10 @@ try
 % *************************************************************
 % VOT: Set random seed to a different value every time.
 % *************************************************************
-RandStream.setGlobalStream(RandStream('mt19937ar', 'Seed', sum(clock)));
+if ~is_octave
+    RandStream.setGlobalStream(RandStream('mt19937ar', 'Seed', sum(clock)));
+end
+
 
 seq.format = 'vot';
 

--- a/feature_extraction/get_fhog.m
+++ b/feature_extraction/get_fhog.m
@@ -12,7 +12,7 @@ else
 end
 
 [im_height, im_width, num_im_chan, num_images] = size(im);
-feature_image = zeros(floor(im_height/cell_size), floor(im_width/cell_size), fparam.nDim, num_images, 'like', gparam.data_type);
+feature_image = zeros(floor(im_height/cell_size), floor(im_width/cell_size), fparam.nDim, num_images, class(gparam.data_type));
 
 for k = 1:num_images
     hog_image = fhog(single(im(:,:,:,k)), cell_size, fparam.nOrients);

--- a/feature_extraction/integralVecImage.m
+++ b/feature_extraction/integralVecImage.m
@@ -3,7 +3,7 @@ function intImage = integralVecImage(I)
 % Compute the integral image of I.
 
 if ~isempty(I)
-    intImage = zeros(size(I,1)+1, size(I,2)+1, size(I,3), size(I,4), 'like', I);
+    intImage = zeros(size(I,1)+1, size(I,2)+1, size(I,3), size(I,4), class(I));
     intImage(2:end, 2:end, :, :) = cumsum(cumsum(I,1),2);
 else
     intImage = [];

--- a/implementation/dim_reduction/init_projection_matrix.m
+++ b/implementation/dim_reduction/init_projection_matrix.m
@@ -11,7 +11,7 @@ x = cellfun(@(x) bsxfun(@minus, x, mean(x, 1)), x, 'uniformoutput', false);
 
 if strcmpi(params.proj_init_method, 'pca')
     [projection_matrix, ~, ~] = cellfun(@(x) svd(x' * x), x, 'uniformoutput', false);
-    projection_matrix = cellfun(@(P, dim) cast(P(:,1:dim), 'like', params.data_type), projection_matrix, compressed_dim_cell, 'uniformoutput', false);
+    projection_matrix = cellfun(@(P, dim) cast(P(:,1:dim), class(params.data_type)), projection_matrix, compressed_dim_cell, 'uniformoutput', false);
 elseif strcmpi(params.proj_init_method, 'rand_uni')
     projection_matrix = cellfun(@(x, dim) randn(size(x,2), dim, 'like', params.data_type), x, compressed_dim_cell, 'uniformoutput', false);
     projection_matrix = cellfun(@(P) bsxfun(@rdivide, P, sqrt(sum(P.^2,1))), projection_matrix, 'uniformoutput', false);

--- a/implementation/fourier_tools/cfft2.m
+++ b/implementation/fourier_tools/cfft2.m
@@ -1,7 +1,7 @@
 function xf = cfft2(x)
 
 % Find the data type
-data_type_complex = complex(zeros(1, 'like', x));
+data_type_complex = complex(zeros(1, class(x)));
 
 % calculate output size
 in_sz = size(x);

--- a/implementation/fourier_tools/cifft2.m
+++ b/implementation/fourier_tools/cifft2.m
@@ -1,6 +1,6 @@
 function x = cifft2(xf)
 
-if isa(xf, 'gpuArray')
+if isa(xf, 'gpuArray') || is_octave()
     x = real(ifft2(ifftshift(ifftshift(xf, 1), 2)));
 else
     x = ifft2(ifftshift(ifftshift(xf, 1), 2), 'symmetric');

--- a/implementation/initialization/get_interp_fourier.m
+++ b/implementation/initialization/get_interp_fourier.m
@@ -38,5 +38,6 @@ if params.interpolation_windowing
     interp2_fs = interp2_fs .* win2(2:end-1)';
 end
 
-interp1_fs = cast(interp1_fs, 'like', params.data_type);
-interp2_fs = cast(interp2_fs, 'like', params.data_type);
+% interp1_fs and interp2_fs are 1x41 matrix with double
+interp1_fs = cast(interp1_fs, class(params.data_type));
+interp2_fs = cast(interp2_fs, class(params.data_type));

--- a/implementation/initialization/get_reg_filter.m
+++ b/implementation/initialization/get_reg_filter.m
@@ -32,7 +32,7 @@ if params.use_reg_window
     reg_window_dft = fftshift(reg_window_dft);
     
     % find the regularization filter by removing the zeros
-    reg_filter = cast(real(reg_window_dft(~all(reg_window_dft==0,2), ~all(reg_window_dft==0,1))), 'like', params.data_type);
+    reg_filter = cast(real(reg_window_dft(~all(reg_window_dft==0,2), ~all(reg_window_dft==0,1))), class(params.data_type));
 else
     % else use a scaled identity matrix
     reg_filter = cast(params.reg_window_min, 'like', params.data_type);

--- a/implementation/octave_support/gather.m
+++ b/implementation/octave_support/gather.m
@@ -1,0 +1,7 @@
+function results = gather(param)
+%
+% Octave's Parallel package does not provide this function
+%
+% Return: Just return the input
+
+results = param;

--- a/implementation/octave_support/is_octave.m
+++ b/implementation/octave_support/is_octave.m
@@ -1,0 +1,17 @@
+function in_octave = is_octave()
+%
+% is_octave Test if run in GNU/Octave
+%
+% Return: true if the environment is Octave.
+%
+% Refer https://www.gnu.org/software/octave/doc/v4.0.1/How-to-distinguish-between-Octave-and-Matlab_003f.html
+%
+
+    persistent cacheval;  % speeds up repeated calls
+
+    if isempty (cacheval)
+        cacheval = (exist ('OCTAVE_VERSION', 'builtin') > 0);
+    end
+
+    in_octave = cacheval;
+end

--- a/implementation/sample_space_model/find_gram_vector.m
+++ b/implementation/sample_space_model/find_gram_vector.m
@@ -9,13 +9,13 @@ function gram_vector = find_gram_vector(samplesf, new_sample, num_training_sampl
 % match is not important, small error in the distance computation doesn't
 % matter
 
-gram_vector = inf(params.nSamples,1,'like', params.data_type);
+gram_vector = inf(params.nSamples,1, class(params.data_type));
 
 num_feature_blocks = numel(new_sample);
 
 if num_training_samples == params.nSamples
     % This if statement is only for speed
-    ip = zeros(1,'like', params.data_type);
+    ip = zeros(1,class(params.data_type));
     for k = 1:num_feature_blocks
         ip_block = 2*reshape(samplesf{k}, num_training_samples, []) * conj(new_sample{k}(:));
         ip = ip + real(ip_block);
@@ -23,7 +23,7 @@ if num_training_samples == params.nSamples
     
     gram_vector = ip;
 elseif num_training_samples > 0
-    ip = zeros(1,'like', params.data_type);
+    ip = zeros(1, class(params.data_type));
     for k = 1:num_feature_blocks
         ip_block = 2*reshape(samplesf{k}(1:num_training_samples,:,:,:),num_training_samples, []) * conj(new_sample{k}(:));
         ip = ip + real(ip_block);

--- a/implementation/sample_space_model/update_sample_space_model.m
+++ b/implementation/sample_space_model/update_sample_space_model.m
@@ -31,7 +31,7 @@ gram_vector = find_gram_vector(samplesf, new_train_sample, num_training_samples,
 % since we wannt to merge samples that are similar, and finding the best
 % match is not important, small error in the distance computation doesn't
 % matter
-new_train_sample_norm =  zeros(1,'like', params.data_type);
+new_train_sample_norm =  zeros(1, class(params.data_type));
 
 for k = 1:num_feature_blocks
     new_train_sample_norm = new_train_sample_norm + real(2*(new_train_sample{k}(:)' * new_train_sample{k}(:)));

--- a/implementation/scale_filter/scale_filter_track.m
+++ b/implementation/scale_filter/scale_filter_track.m
@@ -12,7 +12,11 @@ xs = feature_projection_scale(xs, scale_filter.basis, scale_filter.window);
 % Get scores
 xsf = fft(xs, [], 2);
 scale_responsef = sum(scale_filter.sf_num .* xsf, 1) ./ (scale_filter.sf_den + params.lambda);
-interp_scale_response = ifft(resizeDFT(scale_responsef, params.number_of_interp_scales), 'symmetric');
+if is_octave()
+    interp_scale_response = real(ifft(resizeDFT(scale_responsef, params.number_of_interp_scales)));
+else
+    interp_scale_response = ifft(resizeDFT(scale_responsef, params.number_of_interp_scales), 'symmetric');
+end
 
 recovered_scale_index = find(interp_scale_response == max(interp_scale_response(:)), 1);
 

--- a/implementation/tracker.m
+++ b/implementation/tracker.m
@@ -4,6 +4,12 @@ function results = tracker(params)
 %% Initialization
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% Load additional packages from Octave Forge
+if is_octave
+    pkg load signal;
+    pkg load image;
+end
+
 % Get sequence info
 [seq, im] = get_sequence_info(params.seq);
 params = rmfield(params, 'seq');
@@ -142,13 +148,14 @@ kx = cellfun(@(sz) -ceil((sz(2) - 1)/2) : 0, filter_sz_cell, 'uniformoutput', fa
 
 % construct the Gaussian label function using Poisson formula
 sig_y = sqrt(prod(floor(base_target_sz))) * params.output_sigma_factor * (output_sz ./ img_support_sz);
+% yf_y and yf_x, is 1x1x2 cell with vector
 yf_y = cellfun(@(ky) single(sqrt(2*pi) * sig_y(1) / output_sz(1) * exp(-2 * (pi * sig_y(1) * ky / output_sz(1)).^2)), ky, 'uniformoutput', false);
 yf_x = cellfun(@(kx) single(sqrt(2*pi) * sig_y(2) / output_sz(2) * exp(-2 * (pi * sig_y(2) * kx / output_sz(2)).^2)), kx, 'uniformoutput', false);
-yf = cellfun(@(yf_y, yf_x) cast(yf_y * yf_x, 'like', params.data_type), yf_y, yf_x, 'uniformoutput', false);
+yf = cellfun(@(yf_y, yf_x) cast(yf_y * yf_x, class(params.data_type)), yf_y, yf_x, 'uniformoutput', false);
 
 % construct cosine window
 cos_window = cellfun(@(sz) hann(sz(1)+2)*hann(sz(2)+2)', feature_sz_cell, 'uniformoutput', false);
-cos_window = cellfun(@(cos_window) cast(cos_window(2:end-1,2:end-1), 'like', params.data_type), cos_window, 'uniformoutput', false);
+cos_window = cellfun(@(cos_window) cast(cos_window(2:end-1,2:end-1), 'single'), cos_window, 'uniformoutput', false);
 
 % Compute Fourier series of interpolation function
 [interp1_fs, interp2_fs] = cellfun(@(sz) get_interp_fourier(sz, params), filter_sz_cell, 'uniformoutput', false);
@@ -204,17 +211,17 @@ seq.time = 0;
 
 % Initialize and allocate
 prior_weights = zeros(params.nSamples,1, 'single');
-sample_weights = cast(prior_weights, 'like', params.data_type);
+sample_weights = cast(prior_weights, class(params.data_type));
 samplesf = cell(1, 1, num_feature_blocks);
 if params.use_gpu
     % In the GPU version, the data is stored in a more normal way since we
     % dont have to use mtimesx.
     for k = 1:num_feature_blocks
-        samplesf{k} = zeros(filter_sz(k,1),(filter_sz(k,2)+1)/2,sample_dim(k),params.nSamples, 'like', params.data_type_complex);
+        samplesf{k} = complex(zeros(filter_sz(k,1),(filter_sz(k,2)+1)/2,sample_dim(k),params.nSamples))
     end
 else
     for k = 1:num_feature_blocks
-        samplesf{k} = zeros(params.nSamples,sample_dim(k),filter_sz(k,1),(filter_sz(k,2)+1)/2, 'like', params.data_type_complex);
+        samplesf{k} = complex(zeros(params.nSamples,sample_dim(k),filter_sz(k,1),(filter_sz(k,2)+1)/2), 0);
     end
 end
 
@@ -463,7 +470,7 @@ while true
         end
     end
 
-    sample_weights = cast(prior_weights, 'like', params.data_type);
+    sample_weights = cast(prior_weights, class(params.data_type));
            
     train_tracker = (seq.frame < params.skip_after_frame) || (frames_since_last_train >= params.train_gap);
     
@@ -483,7 +490,7 @@ while true
                 init_CG_opts.maxit = ceil(params.init_CG_iter / params.init_GN_iter);
             
                 hf = cell(2,1,num_feature_blocks);
-                proj_energy = cellfun(@(P, yf) 2*sum(abs(yf(:)).^2) / sum(feature_dim) * ones(size(P), 'like', params.data_type), projection_matrix, yf, 'uniformoutput', false);
+                proj_energy = cellfun(@(P, yf) 2*sum(abs(yf(:)).^2) / sum(feature_dim) * ones(size(P), class(params.data_type)), projection_matrix, yf, 'uniformoutput', false);
             else
                 CG_opts.maxit = params.init_CG_iter; % Number of initial iterations if projection matrix is not updated
             
@@ -492,7 +499,7 @@ while true
             
             % Initialize the filter with zeros
             for k = 1:num_feature_blocks
-                hf{1,1,k} = zeros([filter_sz(k,1) (filter_sz(k,2)+1)/2 sample_dim(k)], 'like', params.data_type_complex);
+                hf{1,1,k} = complex(zeros([filter_sz(k,1) (filter_sz(k,2)+1)/2 sample_dim(k)]));
             end
         else
             CG_opts.maxit = params.CG_iter;
@@ -648,7 +655,9 @@ while true
             imagesc(im_to_show);
             hold on;
             resp_handle = imagesc(xs, ys, sampled_scores_display); colormap hsv;
-            alpha(resp_handle, 0.5);
+            if ~is_octave()
+                alpha(resp_handle, 0.5);
+            end
             rectangle('Position',rect_position_vis, 'EdgeColor','g', 'LineWidth',2);
             text(10, 10, int2str(seq.frame), 'color', [0 1 1]);
             hold off;

--- a/implementation/tracker.m
+++ b/implementation/tracker.m
@@ -148,14 +148,13 @@ kx = cellfun(@(sz) -ceil((sz(2) - 1)/2) : 0, filter_sz_cell, 'uniformoutput', fa
 
 % construct the Gaussian label function using Poisson formula
 sig_y = sqrt(prod(floor(base_target_sz))) * params.output_sigma_factor * (output_sz ./ img_support_sz);
-% yf_y and yf_x, is 1x1x2 cell with vector
 yf_y = cellfun(@(ky) single(sqrt(2*pi) * sig_y(1) / output_sz(1) * exp(-2 * (pi * sig_y(1) * ky / output_sz(1)).^2)), ky, 'uniformoutput', false);
 yf_x = cellfun(@(kx) single(sqrt(2*pi) * sig_y(2) / output_sz(2) * exp(-2 * (pi * sig_y(2) * kx / output_sz(2)).^2)), kx, 'uniformoutput', false);
 yf = cellfun(@(yf_y, yf_x) cast(yf_y * yf_x, class(params.data_type)), yf_y, yf_x, 'uniformoutput', false);
 
 % construct cosine window
 cos_window = cellfun(@(sz) hann(sz(1)+2)*hann(sz(2)+2)', feature_sz_cell, 'uniformoutput', false);
-cos_window = cellfun(@(cos_window) cast(cos_window(2:end-1,2:end-1), 'single'), cos_window, 'uniformoutput', false);
+cos_window = cellfun(@(cos_window) cast(cos_window(2:end-1,2:end-1), class(params.data_type)), cos_window, 'uniformoutput', false);
 
 % Compute Fourier series of interpolation function
 [interp1_fs, interp2_fs] = cellfun(@(sz) get_interp_fourier(sz, params), filter_sz_cell, 'uniformoutput', false);
@@ -217,11 +216,11 @@ if params.use_gpu
     % In the GPU version, the data is stored in a more normal way since we
     % dont have to use mtimesx.
     for k = 1:num_feature_blocks
-        samplesf{k} = complex(zeros(filter_sz(k,1),(filter_sz(k,2)+1)/2,sample_dim(k),params.nSamples))
+        samplesf{k} = complex(zeros(filter_sz(k,1),(filter_sz(k,2)+1)/2,sample_dim(k),params.nSamples, class(params.data_type_complex)));
     end
 else
     for k = 1:num_feature_blocks
-        samplesf{k} = complex(zeros(params.nSamples,sample_dim(k),filter_sz(k,1),(filter_sz(k,2)+1)/2), 0);
+        samplesf{k} = complex(zeros(params.nSamples,sample_dim(k),filter_sz(k,1),(filter_sz(k,2)+1)/2, class(params.data_type_complex)));
     end
 end
 
@@ -499,7 +498,7 @@ while true
             
             % Initialize the filter with zeros
             for k = 1:num_feature_blocks
-                hf{1,1,k} = complex(zeros([filter_sz(k,1) (filter_sz(k,2)+1)/2 sample_dim(k)]));
+                hf{1,1,k} = complex(zeros([filter_sz(k,1) (filter_sz(k,2)+1)/2 sample_dim(k)], class(params.data_type_complex)));
             end
         else
             CG_opts.maxit = params.CG_iter;


### PR DESCRIPTION
This PR brings GNU/Octave support

Issues when running in Octave:

- Need load additional packages **image** and **signal** from Octave Forge. 
- `cast()` does not support **like**, `cast(x, 'like', y)`
- No `gather()` API in **parallel** package of Octave Forge
- No `alpha()` API in **image** package of Octave Forge

Changes:

- Add `implmentation/octave_support` dir for all Octave related works.
    - **is_octave.m**, check if running in Octave
    - **gather.m**, Octave dummy implementation of Matlab Parallel Toolbox gather()
- Add a new parameter `is_octave` into  `benchmark_tracker_wrapper()`
- Replace `cast(x, 'like', y)` to `cast(x, class(y))`
- Disable `alpha()` when display `bbox` in **demo_ECO** script